### PR TITLE
Fixed issue when used with grunt-contrib-watch

### DIFF
--- a/tasks/hjson.js
+++ b/tasks/hjson.js
@@ -27,11 +27,12 @@ module.exports=function(grunt) {
       var destExt=path.extname(f.dest);
 
       if (f.src.length!==1)
-        throw new Error('Each source file needs to map to one destination file!');
+        next(new Error('Each source file needs to map to one destination file!'));
 
       var res=convert(f.src[0], destExt);
       grunt.file.write(destFile, res);
       grunt.log.writeln('File "'+destFile+'" converted.');
+      next(true);//success
     }, done);
   });
 


### PR DESCRIPTION
In the grunt.registerMultiTask callback, this.async()'s done function was never being called, and it was keeping watched hjson files from being updated more than once (locking up watch
in general)

Per the grunt docs ( http://gruntjs.com/api/inside-tasks#this.async ) and the docs for async  (https://github.com/caolan/async ) the callback for forEach has to be called on error and success. Modified the callback to return the error to the done function (eg, next) and to call it with success.
